### PR TITLE
Passing users (full path of ../data/ntuples/.../trigger_info.yml) as parameter to cmsRun

### DIFF
--- a/python/ntp_utils/ntp_crab.py
+++ b/python/ntp_utils/ntp_crab.py
@@ -76,7 +76,7 @@ class ntp_crab:
       config.JobType.maxMemoryMB = 10000
       config.JobType.inputFiles = [self.__versiondir+'/trigger_info.yml']
       # Passing cmsRun parameters
-      config.JobType.pyCfgParams = ["year="+str(self.__opts.year),"type="+self.__opts.type,"triggerInfo=trigger_info.yml"]
+      config.JobType.pyCfgParams = ["year="+str(self.__opts.year),"type="+self.__opts.type]
       if info:
          for var,value in info.iteritems():
             if var=='xsection_pb':

--- a/python/ntp_utils/ntp_crab.py
+++ b/python/ntp_utils/ntp_crab.py
@@ -76,7 +76,7 @@ class ntp_crab:
       config.JobType.maxMemoryMB = 10000
       config.JobType.inputFiles = [self.__versiondir+'/trigger_info.yml']
       # Passing cmsRun parameters
-      config.JobType.pyCfgParams = ["year="+str(self.__opts.year),"type="+self.__opts.type]
+      config.JobType.pyCfgParams = ["year="+str(self.__opts.year),"type="+self.__opts.type,"triggerInfo="+self.__versiondir+"/trigger_info.yml"]
       if info:
          for var,value in info.iteritems():
             if var=='xsection_pb':


### PR DESCRIPTION
crab executes python scripts preparing the complete python config (inputs/PSetDump.py) file before submitting the job, and not during running the job.